### PR TITLE
pages配下の各ファイルでexport名を変更

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -4,14 +4,14 @@ import Image from "next/image";
 import styles from "../styles/Home.module.css";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
-import { About } from "../components/PageContainer/About";
+import { About as AboutComponent } from "../components/PageContainer/About";
 import { BlogArchive } from "../components/PageContainer/BlogArchive";
 import { PortFolio } from "../components/PageContainer/PortFolio";
 import { GitHub } from "../components/PageContainer/GitHub";
 import { Twitter } from "../components/PageContainer/Twitter";
 import { Layout } from "src/components/Layout";
 
-const Home: NextPage = () => {
+const About: NextPage = () => {
   return (
     <div className={styles.container}>
       <Head>
@@ -20,10 +20,10 @@ const Home: NextPage = () => {
       </Head>
 
       <Layout>
-        <About />
+        <AboutComponent />
       </Layout>
     </div>
   );
 };
 
-export default Home;
+export default About;

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -10,7 +10,7 @@ import { PortFolio } from "../components/PageContainer/PortFolio";
 import { GitHub } from "../components/PageContainer/GitHub";
 import { Twitter } from "../components/PageContainer/Twitter";
 import { Layout } from "src/components/Layout";
-const Home: NextPage = () => {
+const Blog: NextPage = () => {
   return (
     <div className={styles.container}>
       <Head>
@@ -24,4 +24,4 @@ const Home: NextPage = () => {
   );
 };
 
-export default Home;
+export default Blog;

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -12,7 +12,7 @@ import { GitHub } from "../components/PageContainer/GitHub";
 import { Twitter } from "../components/PageContainer/Twitter";
 import { Layout } from "src/components/Layout";
 
-const Home: NextPage = () => {
+const Contact: NextPage = () => {
   return (
     <div className={styles.container}>
       <Head>
@@ -26,4 +26,4 @@ const Home: NextPage = () => {
   );
 };
 
-export default Home;
+export default Contact;

--- a/src/pages/portfolio.tsx
+++ b/src/pages/portfolio.tsx
@@ -11,7 +11,7 @@ import { GitHub } from "../components/PageContainer/GitHub";
 import { Twitter } from "../components/PageContainer/Twitter";
 import { Layout } from "src/components/Layout";
 
-const Home: NextPage = () => {
+const Portfolio: NextPage = () => {
   return (
     <div className={styles.container}>
       <Head>
@@ -25,4 +25,4 @@ const Home: NextPage = () => {
   );
 };
 
-export default Home;
+export default Portfolio;


### PR DESCRIPTION
## やったこと
pages配下にある各ページ（e.g. `blog.tsx`,`about.tsx`など）では全てHomeがexportされていたので、各ページ名に併せました。

## なぜやるのか
- 各ページごとにexportするfunction名はページ名に合わせるのがよいです。

## 補足事項
- 全て同じ名前で起こりうる弊害的なものは、Next.jsのドキュメントにはみつかりませんでした、、。なので、別に問題等は起きないかもですが、exportする関数名はページに合わせるのが一般的かと、笑