### PR TITLE
Header関連のリファクタを行いました！

### DIFF
--- a/src/components/Header/headerLinks.ts
+++ b/src/components/Header/headerLinks.ts
@@ -1,0 +1,19 @@
+//navigationのlinkを定義
+export const NAV_LINKS = [
+  {
+    href: "/about",
+    label: "About",
+  },
+  {
+    href: "/blog",
+    label: "Blog",
+  },
+  {
+    href: "/portfolio",
+    label: "Portfolio",
+  },
+  {
+    href: "/contact",
+    label: "Contact",
+  },
+] as const;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { DarkButton } from "src/components/PageContainer/Darkbutton";
 import { Box, Burger } from "@mantine/core";
 import { DrawerMenu } from "../PageContainer/DrawerMenu";
+import { NAV_LINKS } from "./headerLinks";
 
 export function Header() {
   return (
@@ -18,18 +19,12 @@ export function Header() {
         </div>
         {/* スマホ時はハンバーガーに */}
         <div className="flex ml-auto pc-menu">
-          <Link href="/about">
-            <a className=" mr-4">About</a>
-          </Link>
-          <Link href="/blog">
-            <a className=" mr-4">Blog</a>
-          </Link>
-          <Link href="/portfolio">
-            <a className=" mr-4">Portfolio</a>
-          </Link>
-          <Link href="/contact">
-            <a className=" mr-4">Contact</a>
-          </Link>
+          {/* navigationをmapで表示 */}
+          {NAV_LINKS.map((link) => (
+            <Link key={link.label} href={`${link.href}`}>
+              <a className="mr-4">{link.label}</a>
+            </Link>
+          ))}
         </div>
         <DarkButton />
       </div>

--- a/src/components/PageContainer/DrawerMenu.tsx
+++ b/src/components/PageContainer/DrawerMenu.tsx
@@ -5,9 +5,11 @@ import React from "react";
 import { DarkButton } from "src/components/PageContainer/Darkbutton";
 import { Drawer, Button, Group, Box, Burger } from "@mantine/core";
 import { useState } from "react";
+import { NAV_LINKS } from "../Header/headerLinks";
 
 export const DrawerMenu = () => {
   const [opened, setOpened] = useState(false);
+
   const title = opened ? "Close navigation" : "Open navigation";
 
   return (
@@ -21,24 +23,18 @@ export const DrawerMenu = () => {
         size="full"
       >
         <div className="flex flex-col font-avenirtitle">
-          <Link href="/about">
-            <a className=" leading-10 text-3xl mt-4 font-bold">About</a>
+          {/* navigationをmapで表示 */}
+          {NAV_LINKS.map((link) => (
+          <Link key={link.label} href={`${link.href}`}>
+            <a onClick={(() => setOpened(false))} className="leading-10 text-3xl mt-4 font-bold">{link.label}</a>
           </Link>
-          <Link href="/blog">
-            <a className=" leading-10 text-3xl mt-4 font-bold">Blog</a>
-          </Link>
-          <Link href="/portfolio">
-            <a className="leading-10  text-3xl mt-4 font-bold">Portfolio</a>
-          </Link>
-          <Link href="/contact">
-            <a className=" leading-10 text-3xl mt-4 font-bold">Contact</a>
-          </Link>
+          ))}
         </div>
       </Drawer>
       {/* スマホ用ドロワー */}
       <Burger
         opened={opened}
-        onClick={() => setOpened((o) => !o)}
+        onClick={() => setOpened(true)}
         title={title}
       />
       {/* <Group position="center">


### PR DESCRIPTION
## やったこと
Header（主にハンバーガーメニューと各リンクの表示方法）についてリファクタリングを行いました。

## なぜやるのか
- 各リンクの表示方法について
  - mapなどのループででリンクを表示したほうがメリットが多いです。
     - ページが増えた時に元で定義しているリンク（今回でいえば`NAV_LINKS`）を増やすだけで、リンクをバグが少なく増やすことができます。
  - `NAV_LINKS`の後に`as const`とすることで、各`href`と`label`が`readonly`になるので、他の人がリンクをタイポしたり、予期しない箇所からのリンクの上書きを防ぐことができます。
![image](https://user-images.githubusercontent.com/85816730/185255988-d33d9b69-2cfb-4ebc-a2d9-8a24d70a58df.png)<br />
- ハンバーガーメニューについて
  - MantineのDrawerを使用すると現状のハンバーガーメニューでは、✖︎マークを押した時しかメニューが閉じません。（リンクをクリックした時に閉じるのは、シンプルに他の画面に遷移するので`opened`フラグが`false`に初期化されるからかと思います。）<br />従って、URLに表示されているパスと同じメニューをクリックしてもメニューが閉じないかと思います。（例えば、`~/blog`にいる時にハンバーガーメニューの`Blog`をクリックしてみてください）
  - なので、各リンクをクリックした時にも`opeded`フラグが`false`になるようclickイベントを加えました。（ただ、他ページに遷移する場合には、ページ遷移よりもメニューが閉じるほうが早いので、元のページが一瞬見えてしまうのがUX的に少しアレですが、、笑 パスと同一ページのみclickイベントを付与するなどで対応するしかないかもですね、、）

## 補足事項
- TypeScriptは僕もまだ学び始めたばかりなので、効果的な使用ができていませんがそこら辺はご理解いただけると幸いですorz
- MantineにDrawerがあるの知りませんでした！僕も次回使ってみようと思います:)